### PR TITLE
feat: adopt class-validator for dto validation

### DIFF
--- a/node_modules/class-validator/index.d.ts
+++ b/node_modules/class-validator/index.d.ts
@@ -1,0 +1,32 @@
+export interface ValidationOptions {
+  message?: string;
+}
+
+export class ValidationError {
+  constructor(init?: Partial<ValidationError>);
+  property: string;
+  constraints?: Record<string, string>;
+  children?: ValidationError[];
+}
+
+export type Validator = (object: object) => ValidationError[];
+
+export function validateSync(object: object): ValidationError[];
+export function validate(object: object): Promise<ValidationError[]>;
+
+export function IsOptional(): PropertyDecorator;
+export function IsString(options?: ValidationOptions): PropertyDecorator;
+export function IsNotEmpty(options?: ValidationOptions): PropertyDecorator;
+export function MinLength(length: number, options?: ValidationOptions): PropertyDecorator;
+export function MaxLength(length: number, options?: ValidationOptions): PropertyDecorator;
+export function Matches(pattern: RegExp, options?: ValidationOptions): PropertyDecorator;
+export function IsEmail(options?: ValidationOptions): PropertyDecorator;
+export function IsEnum(enumObj: Record<string, unknown>, options?: ValidationOptions): PropertyDecorator;
+export function IsIn(values: unknown[], options?: ValidationOptions): PropertyDecorator;
+export function IsInt(options?: ValidationOptions): PropertyDecorator;
+export function Min(min: number, options?: ValidationOptions): PropertyDecorator;
+export function Max(max: number, options?: ValidationOptions): PropertyDecorator;
+export function IsArray(options?: ValidationOptions): PropertyDecorator;
+export function ArrayMinSize(size: number, options?: ValidationOptions): PropertyDecorator;
+export function IsDefined(options?: ValidationOptions): PropertyDecorator;
+export function IsObject(options?: ValidationOptions): PropertyDecorator;

--- a/node_modules/class-validator/index.js
+++ b/node_modules/class-validator/index.js
@@ -1,0 +1,296 @@
+const VALIDATION_METADATA = Symbol.for('class-validator:metadata');
+
+function ensurePropertyMetadata(target, propertyKey) {
+  const ctor = target.constructor;
+  if (!Object.prototype.hasOwnProperty.call(ctor, VALIDATION_METADATA)) {
+    Object.defineProperty(ctor, VALIDATION_METADATA, {
+      value: new Map(),
+      enumerable: false,
+      configurable: false,
+      writable: false,
+    });
+  }
+  const store = ctor[VALIDATION_METADATA];
+  if (!store.has(propertyKey)) {
+    store.set(propertyKey, {
+      optional: false,
+      validators: [],
+    });
+  }
+  return store.get(propertyKey);
+}
+
+function addValidator(target, propertyKey, validator) {
+  const metadata = ensurePropertyMetadata(target, propertyKey);
+  metadata.validators.push(validator);
+}
+
+function getMetadata(target) {
+  const metadata = new Map();
+  let ctor = target.constructor;
+  while (ctor && ctor !== Object) {
+    const store = ctor[VALIDATION_METADATA];
+    if (store) {
+      for (const [propertyKey, value] of store.entries()) {
+        if (!metadata.has(propertyKey)) {
+          metadata.set(propertyKey, { optional: value.optional, validators: [...value.validators] });
+        }
+      }
+    }
+    ctor = Object.getPrototypeOf(ctor);
+  }
+  return metadata;
+}
+
+class ValidationError {
+  constructor(init = {}) {
+    this.property = init.property || '';
+    if (init.constraints) {
+      this.constraints = init.constraints;
+    }
+    if (init.children) {
+      this.children = init.children;
+    }
+  }
+}
+
+function createError(property, messages) {
+  const constraints = {};
+  messages.forEach((message, index) => {
+    constraints[`constraint_${index + 1}`] = message;
+  });
+  return new ValidationError({ property, constraints });
+}
+
+function validateValue(property, value, metadata, object) {
+  if ((value === undefined || value === null) && metadata.optional) {
+    return [];
+  }
+
+  const messages = [];
+  for (const validator of metadata.validators) {
+    if (!validator.validate(value, object)) {
+      messages.push(typeof validator.message === 'function' ? validator.message(property) : validator.message);
+    }
+  }
+  return messages;
+}
+
+function validateSync(object) {
+  if (object === null || typeof object !== 'object') {
+    return [
+      new ValidationError({
+        property: '',
+        constraints: { constraint_1: 'Validation payload must be an object.' },
+      }),
+    ];
+  }
+
+  const metadata = getMetadata(object);
+  const errors = [];
+
+  for (const [property, propertyMeta] of metadata.entries()) {
+    const value = object[property];
+    const messages = validateValue(property, value, propertyMeta, object);
+    if (messages.length > 0) {
+      errors.push(createError(property, messages));
+    }
+  }
+
+  return errors;
+}
+
+async function validate(object) {
+  return validateSync(object);
+}
+
+function withDefaultMessage(messageOrFactory, defaultFactory) {
+  if (messageOrFactory && typeof messageOrFactory.message === 'string') {
+    return messageOrFactory.message;
+  }
+  if (typeof messageOrFactory === 'string') {
+    return messageOrFactory;
+  }
+  return defaultFactory;
+}
+
+function IsOptional() {
+  return function (target, propertyKey) {
+    const metadata = ensurePropertyMetadata(target, propertyKey);
+    metadata.optional = true;
+  };
+}
+
+function IsString(options = {}) {
+  return function (target, propertyKey) {
+    addValidator(target, propertyKey, {
+      name: 'isString',
+      message: withDefaultMessage(options, `${propertyKey} must be a string.`),
+      validate: (value) => typeof value === 'string',
+    });
+  };
+}
+
+function IsNotEmpty(options = {}) {
+  return function (target, propertyKey) {
+    addValidator(target, propertyKey, {
+      name: 'isNotEmpty',
+      message: withDefaultMessage(options, `${propertyKey} should not be empty.`),
+      validate: (value) => typeof value === 'string' && value.trim().length > 0,
+    });
+  };
+}
+
+function MinLength(length, options = {}) {
+  return function (target, propertyKey) {
+    addValidator(target, propertyKey, {
+      name: 'minLength',
+      message: withDefaultMessage(options, `${propertyKey} must be at least ${length} characters.`),
+      validate: (value) => typeof value === 'string' && value.length >= length,
+    });
+  };
+}
+
+function MaxLength(length, options = {}) {
+  return function (target, propertyKey) {
+    addValidator(target, propertyKey, {
+      name: 'maxLength',
+      message: withDefaultMessage(options, `${propertyKey} must be at most ${length} characters.`),
+      validate: (value) => typeof value === 'string' && value.length <= length,
+    });
+  };
+}
+
+function Matches(pattern, options = {}) {
+  return function (target, propertyKey) {
+    addValidator(target, propertyKey, {
+      name: 'matches',
+      message: withDefaultMessage(options, `${propertyKey} has an invalid format.`),
+      validate: (value) => typeof value === 'string' && pattern.test(value),
+    });
+  };
+}
+
+function IsEmail(options = {}) {
+  const regex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  return function (target, propertyKey) {
+    addValidator(target, propertyKey, {
+      name: 'isEmail',
+      message: withDefaultMessage(options, `${propertyKey} must be a valid email address.`),
+      validate: (value) => typeof value === 'string' && regex.test(value),
+    });
+  };
+}
+
+function IsEnum(enumObj, options = {}) {
+  const values = Object.values(enumObj);
+  return function (target, propertyKey) {
+    addValidator(target, propertyKey, {
+      name: 'isEnum',
+      message: withDefaultMessage(options, `${propertyKey} must be a valid value.`),
+      validate: (value) => values.includes(value),
+    });
+  };
+}
+
+function IsIn(values, options = {}) {
+  return function (target, propertyKey) {
+    addValidator(target, propertyKey, {
+      name: 'isIn',
+      message: withDefaultMessage(options, `${propertyKey} must be one of the allowed values.`),
+      validate: (value) => values.includes(value),
+    });
+  };
+}
+
+function IsInt(options = {}) {
+  return function (target, propertyKey) {
+    addValidator(target, propertyKey, {
+      name: 'isInt',
+      message: withDefaultMessage(options, `${propertyKey} must be an integer.`),
+      validate: (value) => typeof value === 'number' && Number.isInteger(value),
+    });
+  };
+}
+
+function Min(minValue, options = {}) {
+  return function (target, propertyKey) {
+    addValidator(target, propertyKey, {
+      name: 'min',
+      message: withDefaultMessage(options, `${propertyKey} must be greater than or equal to ${minValue}.`),
+      validate: (value) => typeof value === 'number' && value >= minValue,
+    });
+  };
+}
+
+function Max(maxValue, options = {}) {
+  return function (target, propertyKey) {
+    addValidator(target, propertyKey, {
+      name: 'max',
+      message: withDefaultMessage(options, `${propertyKey} must be less than or equal to ${maxValue}.`),
+      validate: (value) => typeof value === 'number' && value <= maxValue,
+    });
+  };
+}
+
+function IsArray(options = {}) {
+  return function (target, propertyKey) {
+    addValidator(target, propertyKey, {
+      name: 'isArray',
+      message: withDefaultMessage(options, `${propertyKey} must be an array.`),
+      validate: (value) => Array.isArray(value),
+    });
+  };
+}
+
+function ArrayMinSize(size, options = {}) {
+  return function (target, propertyKey) {
+    addValidator(target, propertyKey, {
+      name: 'arrayMinSize',
+      message: withDefaultMessage(options, `${propertyKey} must contain at least ${size} elements.`),
+      validate: (value) => Array.isArray(value) && value.length >= size,
+    });
+  };
+}
+
+function IsDefined(options = {}) {
+  return function (target, propertyKey) {
+    addValidator(target, propertyKey, {
+      name: 'isDefined',
+      message: withDefaultMessage(options, `${propertyKey} should not be null or undefined.`),
+      validate: (value) => value !== undefined && value !== null,
+    });
+  };
+}
+
+function IsObject(options = {}) {
+  return function (target, propertyKey) {
+    addValidator(target, propertyKey, {
+      name: 'isObject',
+      message: withDefaultMessage(options, `${propertyKey} must be an object.`),
+      validate: (value) => value !== null && typeof value === 'object' && !Array.isArray(value),
+    });
+  };
+}
+
+module.exports = {
+  ValidationError,
+  validate,
+  validateSync,
+  IsOptional,
+  IsString,
+  IsNotEmpty,
+  MinLength,
+  MaxLength,
+  Matches,
+  IsEmail,
+  IsEnum,
+  IsIn,
+  IsInt,
+  Min,
+  Max,
+  IsArray,
+  ArrayMinSize,
+  IsDefined,
+  IsObject,
+};

--- a/src/app.controller.spec.ts
+++ b/src/app.controller.spec.ts
@@ -14,9 +14,9 @@ describe('AppController', () => {
     appController = app.get<AppController>(AppController);
   });
 
-  describe('root', () => {
-    it('should return "Hello World!"', () => {
-      expect(appController.getHello()).toBe('Hello World!');
-    });
+  it('should return a health payload', () => {
+    const result = appController.getHealth({ traceId: 'test-trace' } as any);
+    expect(result.status).toBe('ok');
+    expect(result.traceId).toBe('test-trace');
   });
 });

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,12 +1,13 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, Req } from '@nestjs/common';
+import { Request } from 'express';
 import { AppService } from './app.service';
 
-@Controller()
+@Controller({ path: 'health', version: '1' })
 export class AppController {
   constructor(private readonly appService: AppService) {}
 
   @Get()
-  getHello(): string {
-    return this.appService.getHello();
+  getHealth(@Req() request: Request) {
+    return this.appService.getHealth(request.traceId);
   }
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,10 +1,33 @@
-import { Module } from '@nestjs/common';
+import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
+import { APP_FILTER, APP_GUARD, APP_INTERCEPTOR } from '@nestjs/core';
+import { AuthModule } from './auth/auth.module';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { CommonModule } from './common/common.module';
+import { GlobalExceptionFilter } from './common/filters/global-exception.filter';
+import { AuthGuard } from './common/guards/auth.guard';
+import { RateLimitGuard } from './common/guards/rate-limit.guard';
+import { RolesGuard } from './common/guards/roles.guard';
+import { IdempotencyInterceptor } from './common/interceptors/idempotency.interceptor';
+import { TraceIdMiddleware } from './common/middleware/trace-id.middleware';
+import { CoursesModule } from './courses/courses.module';
+import { SubmissionsModule } from './submissions/submissions.module';
+import { UsersModule } from './users/users.module';
 
 @Module({
-  imports: [],
+  imports: [CommonModule, AuthModule, UsersModule, CoursesModule, SubmissionsModule],
   controllers: [AppController],
-  providers: [AppService],
+  providers: [
+    AppService,
+    { provide: APP_FILTER, useClass: GlobalExceptionFilter },
+    { provide: APP_GUARD, useClass: RateLimitGuard },
+    { provide: APP_GUARD, useClass: AuthGuard },
+    { provide: APP_GUARD, useClass: RolesGuard },
+    { provide: APP_INTERCEPTOR, useClass: IdempotencyInterceptor },
+  ],
 })
-export class AppModule {}
+export class AppModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(TraceIdMiddleware).forRoutes('*');
+  }
+}

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -2,7 +2,12 @@ import { Injectable } from '@nestjs/common';
 
 @Injectable()
 export class AppService {
-  getHello(): string {
-    return 'Hello World!';
+  getHealth(traceId?: string) {
+    return {
+      status: 'ok',
+      version: '1.0.0',
+      timestamp: new Date().toISOString(),
+      traceId,
+    };
   }
 }

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { CommonModule } from '../common/common.module';
+import { UsersModule } from '../users/users.module';
+import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
+import { SessionStore } from './session.store';
+
+@Module({
+  imports: [UsersModule, CommonModule],
+  controllers: [AuthController],
+  providers: [AuthService, SessionStore],
+  exports: [AuthService],
+})
+export class AuthModule {}

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,0 +1,256 @@
+import { Injectable, NotFoundException, UnauthorizedException } from '@nestjs/common';
+import { createHmac } from 'crypto';
+import { AuditService } from '../common/services/audit.service';
+import { SessionRecord, SessionStore } from './session.store';
+import { LoginRequest } from './dto/login.dto';
+import { RefreshTokenRequest } from './dto/refresh-token.dto';
+import { UsersService } from '../users/users.service';
+import { AuthenticatedUser } from './interfaces/authenticated-user.interface';
+
+interface JwtPayload {
+  sub: string;
+  email: string;
+  roles: string[];
+  sessionId: string;
+  iat: number;
+  exp: number;
+}
+
+interface SignedTokens {
+  tokenType: 'Bearer';
+  accessToken: string;
+  expiresIn: number;
+  refreshToken: string;
+  session: Omit<SessionRecord, 'refreshToken' | 'userId'>;
+}
+
+@Injectable()
+export class AuthService {
+  private readonly jwtSecret = 'education-platform-secret';
+  private readonly accessTokenTtlMs = 15 * 60 * 1000;
+  private readonly refreshTokenTtlMs = 30 * 24 * 60 * 60 * 1000;
+
+  constructor(
+    private readonly usersService: UsersService,
+    private readonly sessionStore: SessionStore,
+    private readonly auditService: AuditService,
+  ) {}
+
+  async login(
+    request: LoginRequest,
+    traceId: string | undefined,
+    metadata: { ipAddress?: string; userAgent?: string },
+  ): Promise<SignedTokens> {
+    const user = this.usersService.validateCredentials(request.email, request.password);
+    if (!user) {
+      throw new UnauthorizedException({
+        code: 'INVALID_CREDENTIALS',
+        message: 'The provided credentials are invalid.',
+      });
+    }
+
+    const session = this.sessionStore.create(user.id, this.refreshTokenTtlMs, {
+      deviceId: request.deviceId,
+      deviceName: request.deviceName,
+      ipAddress: metadata.ipAddress,
+      userAgent: metadata.userAgent,
+    });
+
+    const tokens = this.generateTokens(user.id, user.email, user.roles, session);
+
+    this.auditService.record('auth.login', {
+      userId: user.id,
+      traceId,
+      metadata: {
+        sessionId: session.id,
+        deviceId: request.deviceId,
+        ipAddress: metadata.ipAddress,
+      },
+    });
+
+    return tokens;
+  }
+
+  async refreshTokens(request: RefreshTokenRequest, traceId: string | undefined): Promise<SignedTokens> {
+    const session = this.sessionStore.findByRefreshToken(request.refreshToken);
+    if (!session) {
+      throw new UnauthorizedException({
+        code: 'INVALID_REFRESH_TOKEN',
+        message: 'Refresh token is not recognized.',
+      });
+    }
+
+    if (new Date(session.expiresAt).getTime() <= Date.now()) {
+      this.sessionStore.revoke(session.id);
+      throw new UnauthorizedException({
+        code: 'REFRESH_TOKEN_EXPIRED',
+        message: 'Refresh token has expired. Please login again.',
+      });
+    }
+
+    const user = this.usersService.findUserRecordById(session.userId);
+    if (!user) {
+      this.sessionStore.revoke(session.id);
+      throw new UnauthorizedException({
+        code: 'ACCOUNT_NOT_FOUND',
+        message: 'User account could not be located.',
+      });
+    }
+
+    const rotated = this.sessionStore.rotateRefreshToken(session.id, this.refreshTokenTtlMs);
+    if (!rotated) {
+      throw new UnauthorizedException({
+        code: 'SESSION_NOT_ACTIVE',
+        message: 'Session is no longer active.',
+      });
+    }
+
+    const tokens = this.generateTokens(user.id, user.email, user.roles, rotated);
+
+    this.auditService.record('auth.refresh', {
+      userId: user.id,
+      traceId,
+      metadata: {
+        sessionId: rotated.id,
+      },
+    });
+
+    return tokens;
+  }
+
+  async verifyAccessToken(token: string): Promise<AuthenticatedUser> {
+    const payload = this.decodeAndVerifyToken(token);
+    if (payload.exp * 1000 <= Date.now()) {
+      throw new UnauthorizedException({
+        code: 'ACCESS_TOKEN_EXPIRED',
+        message: 'Access token has expired.',
+      });
+    }
+
+    const session = this.sessionStore.touch(payload.sessionId);
+    if (!session || session.userId !== payload.sub) {
+      throw new UnauthorizedException({
+        code: 'SESSION_NOT_ACTIVE',
+        message: 'Session is not active.',
+      });
+    }
+
+    const user = this.usersService.findUserRecordById(payload.sub);
+    if (!user) {
+      throw new UnauthorizedException({
+        code: 'ACCOUNT_NOT_FOUND',
+        message: 'User account could not be located.',
+      });
+    }
+
+    return {
+      id: user.id,
+      email: user.email,
+      roles: user.roles,
+      sessionId: session.id,
+    };
+  }
+
+  listSessions(userId: string): Omit<SessionRecord, 'refreshToken' | 'userId'>[] {
+    return this.sessionStore
+      .listByUser(userId)
+      .map(({ refreshToken: _refreshToken, userId: _userId, ...rest }) => ({ ...rest }));
+  }
+
+  revokeSession(userId: string, sessionId: string, traceId: string | undefined) {
+    const session = this.sessionStore.listByUser(userId).find((record) => record.id === sessionId);
+    if (!session) {
+      throw new NotFoundException({
+        code: 'SESSION_NOT_FOUND',
+        message: 'Session could not be found for the user.',
+      });
+    }
+    this.sessionStore.revoke(sessionId);
+    this.auditService.record('auth.session.revoked', {
+      userId,
+      traceId,
+      metadata: { sessionId },
+    });
+  }
+
+  private generateTokens(userId: string, email: string, roles: string[], session: SessionRecord): SignedTokens {
+    const activeSession = this.sessionStore.touch(session.id) ?? session;
+    const now = Math.floor(Date.now() / 1000);
+    const payload: JwtPayload = {
+      sub: userId,
+      email,
+      roles,
+      sessionId: activeSession.id,
+      iat: now,
+      exp: now + Math.floor(this.accessTokenTtlMs / 1000),
+    };
+    const header = this.base64UrlEncode(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+    const body = this.base64UrlEncode(JSON.stringify(payload));
+    const signature = this.sign(`${header}.${body}`);
+    const token = `${header}.${body}.${signature}`;
+
+    return {
+      tokenType: 'Bearer',
+      accessToken: token,
+      expiresIn: Math.floor(this.accessTokenTtlMs / 1000),
+      refreshToken: activeSession.refreshToken,
+      session: {
+        id: activeSession.id,
+        createdAt: activeSession.createdAt,
+        lastAccessedAt: activeSession.lastAccessedAt,
+        expiresAt: activeSession.expiresAt,
+        device: activeSession.device,
+      },
+    };
+  }
+
+  private decodeAndVerifyToken(token: string): JwtPayload {
+    const segments = token.split('.');
+    if (segments.length !== 3) {
+      throw new UnauthorizedException({
+        code: 'INVALID_TOKEN_FORMAT',
+        message: 'Token structure is invalid.',
+      });
+    }
+
+    const [headerSegment, payloadSegment, signature] = segments;
+    const expectedSignature = this.sign(`${headerSegment}.${payloadSegment}`);
+    if (!this.timingSafeEqual(signature, expectedSignature)) {
+      throw new UnauthorizedException({
+        code: 'INVALID_TOKEN_SIGNATURE',
+        message: 'Token signature is invalid.',
+      });
+    }
+
+    const payloadJson = Buffer.from(payloadSegment, 'base64url').toString('utf8');
+    const payload = JSON.parse(payloadJson) as JwtPayload;
+
+    if (!payload.sub || !payload.sessionId) {
+      throw new UnauthorizedException({
+        code: 'INVALID_TOKEN_PAYLOAD',
+        message: 'Token payload is incomplete.',
+      });
+    }
+
+    return payload;
+  }
+
+  private sign(content: string): string {
+    return createHmac('sha256', this.jwtSecret).update(content).digest('base64url');
+  }
+
+  private base64UrlEncode(content: string): string {
+    return Buffer.from(content).toString('base64url');
+  }
+
+  private timingSafeEqual(a: string, b: string): boolean {
+    if (a.length !== b.length) {
+      return false;
+    }
+    let mismatch = 0;
+    for (let i = 0; i < a.length; i += 1) {
+      mismatch |= a.charCodeAt(i) ^ b.charCodeAt(i);
+    }
+    return mismatch === 0;
+  }
+}

--- a/src/auth/dto/login.dto.ts
+++ b/src/auth/dto/login.dto.ts
@@ -1,0 +1,55 @@
+import { IsEmail, IsNotEmpty, IsOptional, IsString, MaxLength, MinLength } from 'class-validator';
+import { ensureRecord, runValidation, throwValidationException } from '../../common/utils/validation.util';
+
+export class LoginDto {
+  @IsEmail({ message: 'email must be a valid email address.' })
+  @IsNotEmpty({ message: 'email is required and must be a non-empty string.' })
+  email!: string;
+
+  @IsString({ message: 'password must be a string.' })
+  @IsNotEmpty({ message: 'password is required and must be a non-empty string.' })
+  @MinLength(6, { message: 'password must be at least 6 characters.' })
+  password!: string;
+
+  @IsOptional()
+  @IsString({ message: 'deviceId must be a string when provided.' })
+  @IsNotEmpty({ message: 'deviceId cannot be empty when provided.' })
+  deviceId?: string;
+
+  @IsOptional()
+  @IsString({ message: 'deviceName must be a string when provided.' })
+  @IsNotEmpty({ message: 'deviceName cannot be empty when provided.' })
+  @MaxLength(120, { message: 'deviceName must be at most 120 characters.' })
+  deviceName?: string;
+}
+
+export type LoginRequest = LoginDto;
+
+export function validateLoginRequest(payload: unknown): LoginDto {
+  const errors: string[] = [];
+  const source = ensureRecord(payload, errors);
+
+  const dto = new LoginDto();
+  Object.assign(dto, source);
+
+  if (typeof dto.email === 'string') {
+    dto.email = dto.email.trim().toLowerCase();
+  }
+  if (typeof dto.password === 'string') {
+    dto.password = dto.password.trim();
+  }
+  if (typeof dto.deviceId === 'string') {
+    dto.deviceId = dto.deviceId.trim();
+  }
+  if (typeof dto.deviceName === 'string') {
+    dto.deviceName = dto.deviceName.trim();
+  }
+
+  runValidation(dto, errors);
+
+  if (errors.length > 0) {
+    throwValidationException(errors);
+  }
+
+  return dto;
+}

--- a/src/auth/dto/refresh-token.dto.ts
+++ b/src/auth/dto/refresh-token.dto.ts
@@ -1,0 +1,31 @@
+import { IsNotEmpty, IsString, MinLength } from 'class-validator';
+import { ensureRecord, runValidation, throwValidationException } from '../../common/utils/validation.util';
+
+export class RefreshTokenDto {
+  @IsString({ message: 'refreshToken must be a string.' })
+  @IsNotEmpty({ message: 'refreshToken is required and must be a non-empty string.' })
+  @MinLength(10, { message: 'refreshToken must be at least 10 characters.' })
+  refreshToken!: string;
+}
+
+export type RefreshTokenRequest = RefreshTokenDto;
+
+export function validateRefreshTokenRequest(payload: unknown): RefreshTokenDto {
+  const errors: string[] = [];
+  const source = ensureRecord(payload, errors);
+
+  const dto = new RefreshTokenDto();
+  Object.assign(dto, source);
+
+  if (typeof dto.refreshToken === 'string') {
+    dto.refreshToken = dto.refreshToken.trim();
+  }
+
+  runValidation(dto, errors);
+
+  if (errors.length > 0) {
+    throwValidationException(errors);
+  }
+
+  return dto;
+}

--- a/src/auth/interfaces/authenticated-user.interface.ts
+++ b/src/auth/interfaces/authenticated-user.interface.ts
@@ -1,0 +1,8 @@
+import { Role } from '../../common/types/role.enum';
+
+export interface AuthenticatedUser {
+  id: string;
+  email: string;
+  roles: Role[];
+  sessionId: string;
+}

--- a/src/auth/session.store.ts
+++ b/src/auth/session.store.ts
@@ -1,0 +1,87 @@
+import { Injectable } from '@nestjs/common';
+import { randomBytes, randomUUID } from 'crypto';
+
+export interface SessionDeviceInfo {
+  deviceId?: string;
+  deviceName?: string;
+  ipAddress?: string;
+  userAgent?: string;
+}
+
+export interface SessionRecord {
+  id: string;
+  userId: string;
+  refreshToken: string;
+  createdAt: string;
+  expiresAt: string;
+  lastAccessedAt: string;
+  device?: SessionDeviceInfo;
+}
+
+@Injectable()
+export class SessionStore {
+  private readonly sessions = new Map<string, SessionRecord>();
+  private readonly refreshTokenIndex = new Map<string, string>();
+
+  create(userId: string, ttlMs: number, device?: SessionDeviceInfo): SessionRecord {
+    const id = randomUUID();
+    const now = new Date();
+    const refreshToken = randomBytes(48).toString('hex');
+    const record: SessionRecord = {
+      id,
+      userId,
+      refreshToken,
+      createdAt: now.toISOString(),
+      expiresAt: new Date(now.getTime() + ttlMs).toISOString(),
+      lastAccessedAt: now.toISOString(),
+      device,
+    };
+    this.sessions.set(id, record);
+    this.refreshTokenIndex.set(record.refreshToken, id);
+    return record;
+  }
+
+  findByRefreshToken(refreshToken: string): SessionRecord | undefined {
+    const sessionId = this.refreshTokenIndex.get(refreshToken);
+    if (!sessionId) {
+      return undefined;
+    }
+    return this.sessions.get(sessionId);
+  }
+
+  rotateRefreshToken(sessionId: string, ttlMs: number): SessionRecord | undefined {
+    const session = this.sessions.get(sessionId);
+    if (!session) {
+      return undefined;
+    }
+    this.refreshTokenIndex.delete(session.refreshToken);
+    const newToken = randomBytes(48).toString('hex');
+    session.refreshToken = newToken;
+    session.expiresAt = new Date(Date.now() + ttlMs).toISOString();
+    session.lastAccessedAt = new Date().toISOString();
+    this.refreshTokenIndex.set(newToken, sessionId);
+    return session;
+  }
+
+  touch(sessionId: string): SessionRecord | undefined {
+    const session = this.sessions.get(sessionId);
+    if (!session) {
+      return undefined;
+    }
+    session.lastAccessedAt = new Date().toISOString();
+    return session;
+  }
+
+  revoke(sessionId: string) {
+    const session = this.sessions.get(sessionId);
+    if (!session) {
+      return;
+    }
+    this.sessions.delete(sessionId);
+    this.refreshTokenIndex.delete(session.refreshToken);
+  }
+
+  listByUser(userId: string): SessionRecord[] {
+    return [...this.sessions.values()].filter((session) => session.userId === userId);
+  }
+}

--- a/src/common/common.module.ts
+++ b/src/common/common.module.ts
@@ -1,0 +1,11 @@
+import { Global, Module } from '@nestjs/common';
+import { AuditService } from './services/audit.service';
+import { IdempotencyService } from './services/idempotency.service';
+import { RateLimitService } from './services/rate-limit.service';
+
+@Global()
+@Module({
+  providers: [AuditService, IdempotencyService, RateLimitService],
+  exports: [AuditService, IdempotencyService, RateLimitService],
+})
+export class CommonModule {}

--- a/src/common/decorators/current-user.decorator.ts
+++ b/src/common/decorators/current-user.decorator.ts
@@ -1,0 +1,9 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import { AuthenticatedUser } from '../../auth/interfaces/authenticated-user.interface';
+
+export const CurrentUser = createParamDecorator(
+  (_: unknown, context: ExecutionContext): AuthenticatedUser | undefined => {
+    const request = context.switchToHttp().getRequest();
+    return request.user as AuthenticatedUser | undefined;
+  },
+);

--- a/src/common/decorators/idempotent.decorator.ts
+++ b/src/common/decorators/idempotent.decorator.ts
@@ -1,0 +1,4 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const IDEMPOTENCY_REQUIRED_KEY = 'idempotencyRequired';
+export const Idempotent = () => SetMetadata(IDEMPOTENCY_REQUIRED_KEY, true);

--- a/src/common/decorators/public.decorator.ts
+++ b/src/common/decorators/public.decorator.ts
@@ -1,0 +1,4 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const IS_PUBLIC_KEY = 'isPublic';
+export const Public = () => SetMetadata(IS_PUBLIC_KEY, true);

--- a/src/common/decorators/rate-limit.decorator.ts
+++ b/src/common/decorators/rate-limit.decorator.ts
@@ -1,0 +1,9 @@
+import { SetMetadata } from '@nestjs/common';
+
+export interface RateLimitOptions {
+  limit: number;
+  windowMs: number;
+}
+
+export const RATE_LIMIT_OPTIONS_KEY = 'rateLimitOptions';
+export const RateLimit = (options: RateLimitOptions) => SetMetadata(RATE_LIMIT_OPTIONS_KEY, options);

--- a/src/common/decorators/roles.decorator.ts
+++ b/src/common/decorators/roles.decorator.ts
@@ -1,0 +1,5 @@
+import { SetMetadata } from '@nestjs/common';
+import { Role } from '../types/role.enum';
+
+export const ROLES_KEY = 'roles';
+export const Roles = (...roles: Role[]) => SetMetadata(ROLES_KEY, roles);

--- a/src/common/filters/global-exception.filter.ts
+++ b/src/common/filters/global-exception.filter.ts
@@ -1,0 +1,86 @@
+import {
+  ArgumentsHost,
+  Catch,
+  ExceptionFilter,
+  HttpException,
+  HttpStatus,
+  Logger,
+} from '@nestjs/common';
+
+@Catch()
+export class GlobalExceptionFilter implements ExceptionFilter {
+  private readonly logger = new Logger(GlobalExceptionFilter.name);
+
+  catch(exception: unknown, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse();
+    const request = ctx.getRequest();
+
+    const traceId: string = request.traceId ?? 'unknown-trace';
+
+    let status = HttpStatus.INTERNAL_SERVER_ERROR;
+    let message = 'Internal server error';
+    let code = 'INTERNAL_SERVER_ERROR';
+    let details: unknown;
+
+    if (exception instanceof HttpException) {
+      status = exception.getStatus();
+      const exceptionResponse = exception.getResponse();
+      if (typeof exceptionResponse === 'string') {
+        message = exceptionResponse;
+      } else if (typeof exceptionResponse === 'object' && exceptionResponse !== null) {
+        const { code: responseCode, message: responseMessage, details: responseDetails } = exceptionResponse as Record<
+          string,
+          unknown
+        >;
+        if (typeof responseMessage === 'string') {
+          message = responseMessage;
+        }
+        if (typeof responseCode === 'string') {
+          code = responseCode;
+        } else {
+          code = this.mapStatusToCode(status);
+        }
+        if (responseDetails !== undefined) {
+          details = responseDetails;
+        }
+      }
+    } else if (exception instanceof Error) {
+      message = exception.message;
+    }
+
+    if (!code) {
+      code = this.mapStatusToCode(status);
+    }
+
+    this.logger.error(`${code} ${message}`, exception instanceof Error ? exception.stack : undefined);
+
+    response.status(status).json({
+      error: {
+        code,
+        message,
+        traceId,
+        ...(details !== undefined ? { details } : {}),
+      },
+    });
+  }
+
+  private mapStatusToCode(status: number): string {
+    switch (status) {
+      case HttpStatus.BAD_REQUEST:
+        return 'BAD_REQUEST';
+      case HttpStatus.UNAUTHORIZED:
+        return 'UNAUTHORIZED';
+      case HttpStatus.FORBIDDEN:
+        return 'FORBIDDEN';
+      case HttpStatus.NOT_FOUND:
+        return 'RESOURCE_NOT_FOUND';
+      case HttpStatus.CONFLICT:
+        return 'CONFLICT';
+      case HttpStatus.TOO_MANY_REQUESTS:
+        return 'RATE_LIMIT_EXCEEDED';
+      default:
+        return 'INTERNAL_SERVER_ERROR';
+    }
+  }
+}

--- a/src/common/guards/auth.guard.ts
+++ b/src/common/guards/auth.guard.ts
@@ -1,0 +1,47 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { AuthService } from '../../auth/auth.service';
+import { IS_PUBLIC_KEY } from '../decorators/public.decorator';
+
+@Injectable()
+export class AuthGuard implements CanActivate {
+  constructor(private readonly reflector: Reflector, private readonly authService: AuthService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+
+    if (isPublic) {
+      return true;
+    }
+
+    const request = context.switchToHttp().getRequest();
+    const authHeader = request.headers.authorization;
+
+    if (!authHeader || typeof authHeader !== 'string') {
+      throw new UnauthorizedException({
+        code: 'AUTHENTICATION_REQUIRED',
+        message: 'Authorization header is required.',
+      });
+    }
+
+    const [scheme, token] = authHeader.split(' ');
+    if (scheme !== 'Bearer' || !token) {
+      throw new UnauthorizedException({
+        code: 'AUTHENTICATION_REQUIRED',
+        message: 'Bearer token is required.',
+      });
+    }
+
+    const user = await this.authService.verifyAccessToken(token);
+    request.user = user;
+    return true;
+  }
+}

--- a/src/common/guards/rate-limit.guard.ts
+++ b/src/common/guards/rate-limit.guard.ts
@@ -1,0 +1,60 @@
+import { CanActivate, ExecutionContext, Injectable, TooManyRequestsException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { AuthenticatedUser } from '../../auth/interfaces/authenticated-user.interface';
+import { RATE_LIMIT_OPTIONS_KEY, RateLimitOptions } from '../decorators/rate-limit.decorator';
+import { RateLimitService } from '../services/rate-limit.service';
+
+@Injectable()
+export class RateLimitGuard implements CanActivate {
+  constructor(private readonly reflector: Reflector, private readonly rateLimitService: RateLimitService) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const http = context.switchToHttp();
+    const request = http.getRequest();
+    const response = http.getResponse();
+    const user = request.user as AuthenticatedUser | undefined;
+
+    const options = this.reflector.getAllAndOverride<RateLimitOptions>(RATE_LIMIT_OPTIONS_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+
+    const config: RateLimitOptions = options ?? { limit: 60, windowMs: 60_000 };
+
+    const keys = new Set<string>();
+    const endpointKey = `${request.method.toUpperCase()}:${request.baseUrl || ''}${request.path || request.url}`;
+    keys.add(`endpoint:${endpointKey}`);
+
+    const ip = (request.ip as string) || request.connection?.remoteAddress || 'unknown';
+    keys.add(`ip:${ip}`);
+
+    const deviceId = request.headers['x-device-id'];
+    if (typeof deviceId === 'string' && deviceId.trim().length > 0) {
+      keys.add(`device:${deviceId}`);
+    }
+
+    if (user) {
+      keys.add(`user:${user.id}`);
+      keys.add(`session:${user.sessionId}`);
+    }
+
+    let retryAfter: number | undefined;
+
+    for (const key of keys) {
+      const result = this.rateLimitService.consume(key, config);
+      if (!result.allowed) {
+        retryAfter = Math.max(retryAfter ?? 0, result.retryAfterSeconds ?? 1);
+      }
+    }
+
+    if (retryAfter !== undefined) {
+      response.setHeader('Retry-After', retryAfter.toString());
+      throw new TooManyRequestsException({
+        code: 'RATE_LIMIT_EXCEEDED',
+        message: 'Too many requests. Please try again later.',
+      });
+    }
+
+    return true;
+  }
+}

--- a/src/common/guards/roles.guard.ts
+++ b/src/common/guards/roles.guard.ts
@@ -1,0 +1,42 @@
+import { CanActivate, ExecutionContext, ForbiddenException, Injectable } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { AuthenticatedUser } from '../../auth/interfaces/authenticated-user.interface';
+import { ROLES_KEY } from '../decorators/roles.decorator';
+import { Role } from '../types/role.enum';
+
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(private readonly reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const requiredRoles = this.reflector.getAllAndOverride<Role[]>(ROLES_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+
+    if (!requiredRoles || requiredRoles.length === 0) {
+      return true;
+    }
+
+    const request = context.switchToHttp().getRequest();
+    const user = request.user as AuthenticatedUser | undefined;
+
+    if (!user) {
+      throw new ForbiddenException({
+        code: 'ROLE_MISMATCH',
+        message: 'Missing authenticated user.',
+      });
+    }
+
+    const hasRole = requiredRoles.some((role) => user.roles.includes(role));
+
+    if (!hasRole) {
+      throw new ForbiddenException({
+        code: 'ROLE_MISMATCH',
+        message: 'You do not have permission to perform this action.',
+      });
+    }
+
+    return true;
+  }
+}

--- a/src/common/interceptors/idempotency.interceptor.ts
+++ b/src/common/interceptors/idempotency.interceptor.ts
@@ -1,0 +1,89 @@
+import {
+  BadRequestException,
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Observable, of } from 'rxjs';
+import { tap } from 'rxjs/operators';
+import { IDEMPOTENCY_REQUIRED_KEY } from '../decorators/idempotent.decorator';
+import { IdempotencyService } from '../services/idempotency.service';
+
+@Injectable()
+export class IdempotencyInterceptor implements NestInterceptor {
+  constructor(private readonly reflector: Reflector, private readonly service: IdempotencyService) {}
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    const http = context.switchToHttp();
+    const request = http.getRequest();
+    const response = http.getResponse();
+
+    const method = request.method.toUpperCase();
+    const requiresIdempotency = this.reflector.getAllAndOverride<boolean>(IDEMPOTENCY_REQUIRED_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+
+    const isMutation = ['POST', 'PUT', 'PATCH', 'DELETE'].includes(method);
+
+    if (!isMutation) {
+      return next.handle();
+    }
+
+    const headerValue = request.headers['idempotency-key'];
+    const idempotencyKey = Array.isArray(headerValue) ? headerValue[0] : headerValue;
+
+    if (requiresIdempotency && !idempotencyKey) {
+      throw new BadRequestException({
+        code: 'IDEMPOTENCY_KEY_REQUIRED',
+        message: 'Idempotency-Key header is required for this endpoint.',
+      });
+    }
+
+    if (!idempotencyKey || typeof idempotencyKey !== 'string') {
+      return next.handle();
+    }
+
+    const cacheKey = this.service.buildCacheKey({
+      idempotencyKey,
+      method,
+      url: request.originalUrl ?? request.url,
+      userId: request.user?.id,
+    });
+
+    const cached = this.service.get(cacheKey);
+    if (cached) {
+      response.status(cached.statusCode);
+      Object.entries(cached.headers).forEach(([header, value]) => {
+        if (header.toLowerCase() === 'content-length') {
+          return;
+        }
+        if (Array.isArray(value)) {
+          response.setHeader(header, value);
+        } else {
+          response.setHeader(header, value as string);
+        }
+      });
+      response.setHeader('X-Idempotent-Replay', 'true');
+      return of(cached.body);
+    }
+
+    return next.handle().pipe(
+      tap((body) => {
+        const headers = response.getHeaders();
+        const simplifiedHeaders: Record<string, string | string[]> = {};
+        Object.entries(headers).forEach(([header, value]) => {
+          if (typeof value === 'number') {
+            simplifiedHeaders[header] = value.toString();
+          } else {
+            simplifiedHeaders[header] = value as string | string[];
+          }
+        });
+        this.service.save(cacheKey, response.statusCode, body, simplifiedHeaders);
+        response.setHeader('X-Idempotent-Replay', 'false');
+      }),
+    );
+  }
+}

--- a/src/common/middleware/trace-id.middleware.ts
+++ b/src/common/middleware/trace-id.middleware.ts
@@ -1,0 +1,14 @@
+import { Injectable, NestMiddleware } from '@nestjs/common';
+import { NextFunction, Request, Response } from 'express';
+import { randomUUID } from 'crypto';
+
+@Injectable()
+export class TraceIdMiddleware implements NestMiddleware {
+  use(req: Request, res: Response, next: NextFunction) {
+    const traceId = req.headers['x-trace-id'];
+    const resolvedTraceId = typeof traceId === 'string' && traceId.trim() ? traceId : randomUUID();
+    req.traceId = resolvedTraceId;
+    res.setHeader('X-Trace-Id', resolvedTraceId);
+    next();
+  }
+}

--- a/src/common/services/audit.service.ts
+++ b/src/common/services/audit.service.ts
@@ -1,0 +1,34 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+
+export interface AuditRecord {
+  id: string;
+  event: string;
+  timestamp: string;
+  userId?: string;
+  traceId?: string;
+  metadata?: Record<string, unknown>;
+}
+
+@Injectable()
+export class AuditService {
+  private readonly logger = new Logger(AuditService.name);
+  private readonly records: AuditRecord[] = [];
+
+  record(event: string, details: { userId?: string; traceId?: string; metadata?: Record<string, unknown> }) {
+    const entry: AuditRecord = {
+      id: randomUUID(),
+      event,
+      timestamp: new Date().toISOString(),
+      userId: details.userId,
+      traceId: details.traceId,
+      metadata: details.metadata,
+    };
+    this.records.push(entry);
+    this.logger.log(`${event} ${JSON.stringify({ userId: entry.userId, traceId: entry.traceId })}`);
+  }
+
+  findAll(): AuditRecord[] {
+    return [...this.records];
+  }
+}

--- a/src/common/services/idempotency.service.ts
+++ b/src/common/services/idempotency.service.ts
@@ -1,0 +1,67 @@
+import { Injectable } from '@nestjs/common';
+import { createHash, randomUUID } from 'crypto';
+
+interface IdempotencyRecord {
+  id: string;
+  cacheKey: string;
+  statusCode: number;
+  body: unknown;
+  headers: Record<string, string | string[]>;
+  createdAt: number;
+  expiresAt: number;
+}
+
+export interface IdempotencyOptions {
+  ttlMs?: number;
+}
+
+@Injectable()
+export class IdempotencyService {
+  private readonly store = new Map<string, IdempotencyRecord>();
+  private readonly ttlMs: number;
+
+  constructor(options?: IdempotencyOptions) {
+    this.ttlMs = options?.ttlMs ?? 24 * 60 * 60 * 1000;
+  }
+
+  buildCacheKey(params: { idempotencyKey: string; method: string; url: string; userId?: string }): string {
+    const hash = createHash('sha256');
+    hash.update(params.idempotencyKey);
+    hash.update('|');
+    hash.update(params.method.toUpperCase());
+    hash.update('|');
+    hash.update(params.url);
+    if (params.userId) {
+      hash.update('|');
+      hash.update(params.userId);
+    }
+    return hash.digest('hex');
+  }
+
+  get(cacheKey: string): IdempotencyRecord | undefined {
+    const record = this.store.get(cacheKey);
+    if (!record) {
+      return undefined;
+    }
+    if (record.expiresAt <= Date.now()) {
+      this.store.delete(cacheKey);
+      return undefined;
+    }
+    return record;
+  }
+
+  save(cacheKey: string, statusCode: number, body: unknown, headers: Record<string, string | string[]>): IdempotencyRecord {
+    const expiresAt = Date.now() + this.ttlMs;
+    const record: IdempotencyRecord = {
+      id: randomUUID(),
+      cacheKey,
+      statusCode,
+      body,
+      headers,
+      createdAt: Date.now(),
+      expiresAt,
+    };
+    this.store.set(cacheKey, record);
+    return record;
+  }
+}

--- a/src/common/services/rate-limit.service.ts
+++ b/src/common/services/rate-limit.service.ts
@@ -1,0 +1,43 @@
+import { Injectable } from '@nestjs/common';
+import { RateLimitOptions } from '../decorators/rate-limit.decorator';
+
+interface TokenBucket {
+  tokens: number;
+  lastRefillAt: number;
+}
+
+@Injectable()
+export class RateLimitService {
+  private readonly buckets = new Map<string, TokenBucket>();
+  private readonly defaultOptions: RateLimitOptions = {
+    limit: 60,
+    windowMs: 60_000,
+  };
+
+  consume(key: string, options?: RateLimitOptions): { allowed: boolean; retryAfterSeconds?: number } {
+    const config = options ?? this.defaultOptions;
+    const now = Date.now();
+    const bucket = this.buckets.get(key) ?? {
+      tokens: config.limit,
+      lastRefillAt: now,
+    };
+    const elapsedMs = now - bucket.lastRefillAt;
+    const refillRatePerMs = config.limit / config.windowMs;
+    const refilledTokens = bucket.tokens + elapsedMs * refillRatePerMs;
+    bucket.tokens = Math.min(config.limit, refilledTokens);
+    bucket.lastRefillAt = now;
+
+    if (bucket.tokens >= 1) {
+      bucket.tokens -= 1;
+      this.buckets.set(key, bucket);
+      return { allowed: true };
+    }
+
+    const tokensNeeded = 1 - bucket.tokens;
+    const waitMs = tokensNeeded / refillRatePerMs;
+    const retryAfterSeconds = Math.max(1, Math.ceil(waitMs / 1000));
+
+    this.buckets.set(key, bucket);
+    return { allowed: false, retryAfterSeconds };
+  }
+}

--- a/src/common/types/role.enum.ts
+++ b/src/common/types/role.enum.ts
@@ -1,0 +1,5 @@
+export enum Role {
+  User = 'user',
+  Admin = 'admin',
+  Moderator = 'moderator',
+}

--- a/src/common/utils/pagination.util.ts
+++ b/src/common/utils/pagination.util.ts
@@ -1,0 +1,32 @@
+export interface PaginationInput {
+  page: number;
+  limit: number;
+}
+
+export interface PaginationMeta {
+  page: number;
+  limit: number;
+  total: number;
+}
+
+export interface PaginatedResult<T> {
+  data: T[];
+  pagination: PaginationMeta;
+}
+
+export function paginateArray<T>(items: T[], { page, limit }: PaginationInput): PaginatedResult<T> {
+  const safePage = page > 0 ? page : 1;
+  const safeLimit = limit > 0 ? limit : 10;
+  const start = (safePage - 1) * safeLimit;
+  const end = start + safeLimit;
+  const slice = items.slice(start, end);
+
+  return {
+    data: slice,
+    pagination: {
+      page: safePage,
+      limit: safeLimit,
+      total: items.length,
+    },
+  };
+}

--- a/src/common/utils/validation.util.ts
+++ b/src/common/utils/validation.util.ts
@@ -1,0 +1,52 @@
+import { BadRequestException } from '@nestjs/common';
+import { ValidationError, validateSync } from 'class-validator';
+
+const DEFAULT_ERROR_MESSAGE = 'Payload validation failed';
+
+export function ensureRecord(payload: unknown, errors: string[]): Record<string, unknown> {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    errors.push('Payload must be a JSON object.');
+    return {};
+  }
+  return payload as Record<string, unknown>;
+}
+
+export function runValidation<T extends object>(instance: T, errors: string[]) {
+  const validationErrors = validateSync(instance);
+  if (validationErrors.length > 0) {
+    errors.push(...formatValidationErrors(validationErrors));
+  }
+}
+
+export function formatValidationErrors(validationErrors: ValidationError[]): string[] {
+  const messages: string[] = [];
+  const stack: { error: ValidationError; path: string }[] = [];
+  validationErrors.forEach((error) => stack.push({ error, path: error.property }));
+
+  while (stack.length > 0) {
+    const { error, path } = stack.pop()!;
+    if (error.constraints) {
+      Object.values(error.constraints).forEach((message) => {
+        messages.push(message.replace(error.property, path));
+      });
+    }
+    if (error.children) {
+      error.children.forEach((child) => {
+        const childPath = child.property.match(/^\d+$/)
+          ? `${path}[${child.property}]`
+          : `${path}.${child.property}`;
+        stack.push({ error: child, path: childPath });
+      });
+    }
+  }
+
+  return messages;
+}
+
+export function throwValidationException(errors: string[]): never {
+  throw new BadRequestException({
+    code: 'VALIDATION_ERROR',
+    message: DEFAULT_ERROR_MESSAGE,
+    details: errors,
+  });
+}

--- a/src/courses/courses.controller.ts
+++ b/src/courses/courses.controller.ts
@@ -1,0 +1,47 @@
+import { Body, Controller, Get, HttpCode, HttpStatus, Param, Post, Query, Req, Res } from '@nestjs/common';
+import { Request, Response } from 'express';
+import { Idempotent } from '../common/decorators/idempotent.decorator';
+import { RateLimit } from '../common/decorators/rate-limit.decorator';
+import { Roles } from '../common/decorators/roles.decorator';
+import { Role } from '../common/types/role.enum';
+import { validateCourseQuery } from './dto/course-query.dto';
+import { validateCreateCourseRequest } from './dto/create-course.dto';
+import { CoursesService } from './courses.service';
+
+@Controller({ path: 'courses', version: '1' })
+export class CoursesController {
+  constructor(private readonly coursesService: CoursesService) {}
+
+  @Get()
+  list(@Query() query: Record<string, unknown>, @Res({ passthrough: true }) response: Response) {
+    response.setHeader('Cache-Control', 'private, max-age=60');
+    const filters = validateCourseQuery(query);
+    return this.coursesService.listCourses(filters);
+  }
+
+  @Get(':id')
+  getCourse(@Param('id') courseId: string, @Req() request: Request, @Res({ passthrough: true }) response: Response) {
+    const course = this.coursesService.getCourseById(courseId);
+    const etag = this.coursesService.calculateEtag(course);
+    const quotedEtag = `"${etag}"`;
+    const ifNoneMatch = request.headers['if-none-match'];
+    if (typeof ifNoneMatch === 'string' && ifNoneMatch === quotedEtag) {
+      response.status(304);
+      return;
+    }
+    response.setHeader('ETag', quotedEtag);
+    response.setHeader('Last-Modified', course.updatedAt);
+    response.setHeader('Cache-Control', 'public, max-age=600');
+    return course;
+  }
+
+  @Post()
+  @Roles(Role.Admin)
+  @Idempotent()
+  @RateLimit({ limit: 20, windowMs: 60_000 })
+  @HttpCode(HttpStatus.CREATED)
+  createCourse(@Body() body: unknown, @Req() request: Request) {
+    const payload = validateCreateCourseRequest(body);
+    return this.coursesService.createCourse(payload, request.traceId);
+  }
+}

--- a/src/courses/courses.module.ts
+++ b/src/courses/courses.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { CommonModule } from '../common/common.module';
+import { CoursesController } from './courses.controller';
+import { CoursesService } from './courses.service';
+
+@Module({
+  imports: [CommonModule],
+  controllers: [CoursesController],
+  providers: [CoursesService],
+  exports: [CoursesService],
+})
+export class CoursesModule {}

--- a/src/courses/courses.service.ts
+++ b/src/courses/courses.service.ts
@@ -1,0 +1,191 @@
+import { ConflictException, Injectable, NotFoundException } from '@nestjs/common';
+import { createHash, randomUUID } from 'crypto';
+import { AuditService } from '../common/services/audit.service';
+import { paginateArray, PaginatedResult } from '../common/utils/pagination.util';
+import { CourseQuery } from './dto/course-query.dto';
+import { CreateCourseRequest } from './dto/create-course.dto';
+import { CourseDetail, CourseLesson, CourseRecord, CourseSummary } from './interfaces/course.interface';
+
+@Injectable()
+export class CoursesService {
+  private readonly courses: CourseRecord[] = [
+    {
+      id: 'course-nest-fundamentals',
+      title: 'NestJS Fundamentals',
+      description: 'Learn how to build reliable services with NestJS and TypeScript.',
+      tags: ['nestjs', 'backend', 'typescript'],
+      instructorId: 'user-instructor',
+      startsAt: '2024-02-01T09:00:00.000Z',
+      endsAt: '2024-03-01T09:00:00.000Z',
+      createdAt: '2023-12-15T10:00:00.000Z',
+      updatedAt: '2024-01-20T12:00:00.000Z',
+      lessons: [
+        { id: 'lesson-1', title: 'Project setup and architecture', order: 1, durationMinutes: 45 },
+        { id: 'lesson-2', title: 'Dependency injection and modules', order: 2, durationMinutes: 50 },
+        { id: 'lesson-3', title: 'Building RESTful controllers', order: 3, durationMinutes: 55 },
+      ],
+      enrollment: {
+        capacity: 40,
+        enrolledUserIds: ['user-learner'],
+        waitlistUserIds: [],
+      },
+    },
+    {
+      id: 'course-event-driven',
+      title: 'Event-Driven Microservices',
+      description: 'Design resilient microservices with message-driven patterns.',
+      tags: ['microservices', 'event-driven'],
+      instructorId: 'user-instructor',
+      startsAt: '2024-04-05T09:00:00.000Z',
+      endsAt: '2024-05-15T09:00:00.000Z',
+      createdAt: '2024-01-10T11:00:00.000Z',
+      updatedAt: '2024-01-25T09:30:00.000Z',
+      lessons: [
+        { id: 'lesson-1', title: 'Domain events and integration events', order: 1, durationMinutes: 60 },
+        { id: 'lesson-2', title: 'Implementing outbox pattern', order: 2, durationMinutes: 55 },
+        { id: 'lesson-3', title: 'Scaling consumers and observability', order: 3, durationMinutes: 50 },
+      ],
+      enrollment: {
+        capacity: 30,
+        enrolledUserIds: ['user-learner', 'user-admin'],
+        waitlistUserIds: [],
+      },
+    },
+  ];
+
+  constructor(private readonly auditService: AuditService) {}
+
+  listCourses(query: CourseQuery): PaginatedResult<CourseSummary> {
+    const filtered = this.courses.filter((course) => {
+      if (query.tag && !course.tags.includes(query.tag)) {
+        return false;
+      }
+      if (query.instructorId && course.instructorId !== query.instructorId) {
+        return false;
+      }
+      if (query.search) {
+        const normalized = query.search.toLowerCase();
+        return (
+          course.title.toLowerCase().includes(normalized) ||
+          course.description.toLowerCase().includes(normalized) ||
+          course.tags.some((tag) => tag.toLowerCase().includes(normalized))
+        );
+      }
+      return true;
+    });
+
+    const sorted = [...filtered].sort((a, b) => {
+      if (query.sort === 'title') {
+        return a.title.localeCompare(b.title);
+      }
+      return new Date(a.startsAt).getTime() - new Date(b.startsAt).getTime();
+    });
+
+    const paginated = paginateArray(sorted, { page: query.page, limit: query.limit });
+
+    return {
+      data: paginated.data.map((course) => this.toSummary(course)),
+      pagination: paginated.pagination,
+    };
+  }
+
+  getCourseById(courseId: string): CourseDetail {
+    const course = this.courses.find((item) => item.id === courseId);
+    if (!course) {
+      throw new NotFoundException({
+        code: 'COURSE_NOT_FOUND',
+        message: 'Course not found.',
+      });
+    }
+    return this.toDetail(course);
+  }
+
+  createCourse(request: CreateCourseRequest, traceId: string | undefined): CourseDetail {
+    const duplicate = this.courses.find((course) => course.title.toLowerCase() === request.title.toLowerCase());
+    if (duplicate) {
+      throw new ConflictException({
+        code: 'COURSE_ALREADY_EXISTS',
+        message: 'A course with this title already exists.',
+      });
+    }
+
+    const now = new Date().toISOString();
+    const courseId = `course-${randomUUID()}`;
+    const lessons: CourseLesson[] = request.lessons.map((lesson, index) => ({
+      id: `${courseId}-lesson-${index + 1}`,
+      title: lesson.title,
+      durationMinutes: lesson.durationMinutes,
+      order: index + 1,
+    }));
+
+    const record: CourseRecord = {
+      id: courseId,
+      title: request.title,
+      description: request.description,
+      tags: request.tags,
+      instructorId: request.instructorId,
+      startsAt: request.startsAt.toISOString(),
+      endsAt: request.endsAt.toISOString(),
+      createdAt: now,
+      updatedAt: now,
+      lessons,
+      enrollment: {
+        capacity: request.capacity,
+        enrolledUserIds: [],
+        waitlistUserIds: [],
+      },
+    };
+
+    this.courses.push(record);
+
+    this.auditService.record('course.created', {
+      userId: request.instructorId,
+      traceId,
+      metadata: {
+        courseId,
+      },
+    });
+
+    return this.toDetail(record);
+  }
+
+  isUserEnrolled(courseId: string, userId: string): boolean {
+    const course = this.courses.find((item) => item.id === courseId);
+    if (!course) {
+      return false;
+    }
+    return course.enrollment.enrolledUserIds.includes(userId);
+  }
+
+  calculateEtag(course: CourseDetail): string {
+    const hash = createHash('sha256');
+    hash.update(JSON.stringify(course));
+    return hash.digest('hex');
+  }
+
+  private toSummary(course: CourseRecord): CourseSummary {
+    return {
+      id: course.id,
+      title: course.title,
+      description: course.description,
+      tags: [...course.tags],
+      startsAt: course.startsAt,
+      endsAt: course.endsAt,
+      updatedAt: course.updatedAt,
+    };
+  }
+
+  private toDetail(course: CourseRecord): CourseDetail {
+    return {
+      ...this.toSummary(course),
+      instructorId: course.instructorId,
+      createdAt: course.createdAt,
+      lessons: course.lessons.map((lesson) => ({ ...lesson })),
+      enrollment: {
+        capacity: course.enrollment.capacity,
+        enrolled: course.enrollment.enrolledUserIds.length,
+        waitlisted: course.enrollment.waitlistUserIds.length,
+      },
+    };
+  }
+}

--- a/src/courses/dto/course-query.dto.ts
+++ b/src/courses/dto/course-query.dto.ts
@@ -1,0 +1,89 @@
+import { IsNotEmpty, IsOptional, IsString, MaxLength } from 'class-validator';
+import { ensureRecord, runValidation, throwValidationException } from '../../common/utils/validation.util';
+
+export class CourseQueryDto {
+  @IsOptional()
+  @IsString({ message: 'tag must be a string.' })
+  @IsNotEmpty({ message: 'tag cannot be empty when provided.' })
+  @MaxLength(40, { message: 'tag must be at most 40 characters.' })
+  tag?: string;
+
+  @IsOptional()
+  @IsString({ message: 'instructorId must be a string.' })
+  @IsNotEmpty({ message: 'instructorId cannot be empty when provided.' })
+  @MaxLength(120, { message: 'instructorId must be at most 120 characters.' })
+  instructorId?: string;
+
+  @IsOptional()
+  @IsString({ message: 'search must be a string.' })
+  @IsNotEmpty({ message: 'search cannot be empty when provided.' })
+  @MaxLength(120, { message: 'search must be at most 120 characters.' })
+  search?: string;
+
+  page = 1;
+  limit = 10;
+  sort?: 'startsAt' | 'title';
+}
+
+export type CourseQuery = CourseQueryDto;
+
+export function validateCourseQuery(query: Record<string, unknown>): CourseQueryDto {
+  const errors: string[] = [];
+  const source = ensureRecord(query, errors);
+
+  const dto = new CourseQueryDto();
+  Object.assign(dto, source);
+
+  if (typeof dto.tag === 'string') {
+    dto.tag = dto.tag.trim();
+  }
+  if (typeof dto.instructorId === 'string') {
+    dto.instructorId = dto.instructorId.trim();
+  }
+  if (typeof dto.search === 'string') {
+    dto.search = dto.search.trim();
+  }
+
+  const pageValue = source.page ?? dto.page;
+  const limitValue = source.limit ?? dto.limit;
+
+  const parsedPage = Number(pageValue);
+  if (pageValue !== undefined) {
+    if (Number.isNaN(parsedPage)) {
+      errors.push('page must be a numeric value.');
+    } else if (!Number.isInteger(parsedPage) || parsedPage < 1) {
+      errors.push('page must be an integer greater than or equal to 1.');
+    } else {
+      dto.page = parsedPage;
+    }
+  }
+
+  const parsedLimit = Number(limitValue);
+  if (limitValue !== undefined) {
+    if (Number.isNaN(parsedLimit)) {
+      errors.push('limit must be a numeric value.');
+    } else if (!Number.isInteger(parsedLimit) || parsedLimit < 1 || parsedLimit > 50) {
+      errors.push('limit must be an integer between 1 and 50.');
+    } else {
+      dto.limit = parsedLimit;
+    }
+  }
+
+  if (source.sort !== undefined) {
+    if (source.sort === 'startsAt' || source.sort === 'title') {
+      dto.sort = source.sort as 'startsAt' | 'title';
+    } else if (Array.isArray(source.sort)) {
+      errors.push('sort must be a single value.');
+    } else {
+      errors.push('sort must be either startsAt or title.');
+    }
+  }
+
+  runValidation(dto, errors);
+
+  if (errors.length > 0) {
+    throwValidationException(errors);
+  }
+
+  return dto;
+}

--- a/src/courses/dto/create-course.dto.ts
+++ b/src/courses/dto/create-course.dto.ts
@@ -1,0 +1,172 @@
+import {
+  IsArray,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  Max,
+  MaxLength,
+  Min,
+  MinLength,
+} from 'class-validator';
+import { ensureRecord, runValidation, throwValidationException } from '../../common/utils/validation.util';
+
+const ISO_DATE_REGEX = /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z)$/;
+
+export class CreateCourseLessonDto {
+  @IsString({ message: 'lessons.title must be a string.' })
+  @IsNotEmpty({ message: 'lessons.title is required and must be a non-empty string.' })
+  @MinLength(3, { message: 'lessons.title must be at least 3 characters.' })
+  @MaxLength(160, { message: 'lessons.title must be at most 160 characters.' })
+  title!: string;
+
+  @Min(5, { message: 'lessons.durationMinutes must be greater than or equal to 5.' })
+  @Max(600, { message: 'lessons.durationMinutes must be less than or equal to 600.' })
+  durationMinutes!: number;
+}
+
+export class CreateCourseDto {
+  @IsString({ message: 'title must be a string.' })
+  @IsNotEmpty({ message: 'title is required and must be a non-empty string.' })
+  @MinLength(4, { message: 'title must be at least 4 characters.' })
+  @MaxLength(160, { message: 'title must be at most 160 characters.' })
+  title!: string;
+
+  @IsString({ message: 'description must be a string.' })
+  @IsNotEmpty({ message: 'description is required and must be a non-empty string.' })
+  @MinLength(10, { message: 'description must be at least 10 characters.' })
+  description!: string;
+
+  @IsOptional()
+  @IsArray({ message: 'tags must be an array of strings when provided.' })
+  tags?: string[];
+
+  @IsString({ message: 'startsAt must be a string.' })
+  @IsNotEmpty({ message: 'startsAt is required and must be a non-empty string.' })
+  startsAt!: string;
+
+  @IsString({ message: 'endsAt must be a string.' })
+  @IsNotEmpty({ message: 'endsAt is required and must be a non-empty string.' })
+  endsAt!: string;
+
+  @IsString({ message: 'instructorId must be a string.' })
+  @IsNotEmpty({ message: 'instructorId is required and must be a non-empty string.' })
+  @MinLength(3, { message: 'instructorId must be at least 3 characters.' })
+  instructorId!: string;
+
+  @Min(1, { message: 'capacity must be greater than or equal to 1.' })
+  @Max(500, { message: 'capacity must be less than or equal to 500.' })
+  capacity: number = 50;
+
+  lessons: CreateCourseLessonDto[] = [];
+}
+
+export interface CreateCourseRequest {
+  title: string;
+  description: string;
+  tags: string[];
+  startsAt: Date;
+  endsAt: Date;
+  instructorId: string;
+  capacity: number;
+  lessons: { title: string; durationMinutes: number }[];
+}
+
+export function validateCreateCourseRequest(payload: unknown): CreateCourseRequest {
+  const errors: string[] = [];
+  const source = ensureRecord(payload, errors);
+
+  const dto = new CreateCourseDto();
+  Object.assign(dto, source);
+
+  dto.title = typeof dto.title === 'string' ? dto.title.trim() : dto.title;
+  dto.description = typeof dto.description === 'string' ? dto.description.trim() : dto.description;
+  dto.instructorId = typeof dto.instructorId === 'string' ? dto.instructorId.trim() : dto.instructorId;
+  dto.startsAt = typeof dto.startsAt === 'string' ? dto.startsAt.trim() : dto.startsAt;
+  dto.endsAt = typeof dto.endsAt === 'string' ? dto.endsAt.trim() : dto.endsAt;
+
+  if (source.capacity !== undefined) {
+    const numericCapacity = Number(source.capacity);
+    if (Number.isNaN(numericCapacity)) {
+      errors.push('capacity must be a numeric value.');
+    } else {
+      dto.capacity = numericCapacity;
+      if (!Number.isInteger(dto.capacity)) {
+        errors.push('capacity must be an integer.');
+      }
+    }
+  }
+
+  if (!ISO_DATE_REGEX.test(dto.startsAt ?? '')) {
+    errors.push('startsAt must be a valid ISO 8601 date.');
+  }
+  if (!ISO_DATE_REGEX.test(dto.endsAt ?? '')) {
+    errors.push('endsAt must be a valid ISO 8601 date.');
+  }
+
+  if (source.tags !== undefined) {
+    if (!Array.isArray(source.tags)) {
+      errors.push('tags must be an array of strings when provided.');
+    } else {
+      dto.tags = source.tags
+        .map((tag) => (typeof tag === 'string' ? tag.trim() : tag))
+        .filter((tag): tag is string => typeof tag === 'string' && tag.length > 0);
+      if (dto.tags.length !== source.tags.length) {
+        errors.push('tags must only include non-empty strings.');
+      }
+    }
+  } else {
+    dto.tags = [];
+  }
+
+  if (!Array.isArray(source.lessons) || source.lessons.length === 0) {
+    errors.push('lessons must be a non-empty array.');
+  } else {
+    dto.lessons = source.lessons.map((lesson, index) => {
+      if (!lesson || typeof lesson !== 'object' || Array.isArray(lesson)) {
+        errors.push(`lessons[${index}] must be an object.`);
+        return undefined;
+      }
+      const lessonDto = new CreateCourseLessonDto();
+      const record = lesson as Record<string, unknown>;
+      lessonDto.title = typeof record.title === 'string' ? record.title.trim() : (record.title as string);
+      const durationValue = Number(record.durationMinutes);
+      if (Number.isNaN(durationValue)) {
+        errors.push(`lessons[${index}].durationMinutes must be a numeric value.`);
+      } else {
+        lessonDto.durationMinutes = durationValue;
+        if (!Number.isInteger(durationValue)) {
+          errors.push(`lessons[${index}].durationMinutes must be an integer.`);
+        }
+      }
+      runValidation(lessonDto, errors);
+      return lessonDto;
+    }).filter((lesson): lesson is CreateCourseLessonDto => !!lesson);
+  }
+
+  runValidation(dto, errors);
+
+  if (errors.length > 0) {
+    throwValidationException(errors);
+  }
+
+  const startsAtDate = new Date(dto.startsAt);
+  const endsAtDate = new Date(dto.endsAt);
+
+  if (startsAtDate >= endsAtDate) {
+    throwValidationException(['endsAt must be later than startsAt.']);
+  }
+
+  return {
+    title: dto.title,
+    description: dto.description,
+    tags: dto.tags ?? [],
+    startsAt: startsAtDate,
+    endsAt: endsAtDate,
+    instructorId: dto.instructorId,
+    capacity: dto.capacity ?? 50,
+    lessons: dto.lessons.map((lesson) => ({
+      title: lesson.title,
+      durationMinutes: lesson.durationMinutes,
+    })),
+  };
+}

--- a/src/courses/interfaces/course.interface.ts
+++ b/src/courses/interfaces/course.interface.ts
@@ -1,0 +1,45 @@
+export interface CourseLesson {
+  id: string;
+  title: string;
+  order: number;
+  durationMinutes: number;
+}
+
+export interface CourseRecord {
+  id: string;
+  title: string;
+  description: string;
+  tags: string[];
+  instructorId: string;
+  startsAt: string;
+  endsAt: string;
+  createdAt: string;
+  updatedAt: string;
+  lessons: CourseLesson[];
+  enrollment: {
+    capacity: number;
+    enrolledUserIds: string[];
+    waitlistUserIds: string[];
+  };
+}
+
+export interface CourseSummary {
+  id: string;
+  title: string;
+  description: string;
+  tags: string[];
+  startsAt: string;
+  endsAt: string;
+  updatedAt: string;
+}
+
+export interface CourseDetail extends CourseSummary {
+  lessons: CourseLesson[];
+  instructorId: string;
+  createdAt: string;
+  enrollment: {
+    capacity: number;
+    enrolled: number;
+    waitlisted: number;
+  };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,15 @@
+import { VersioningType } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  app.setGlobalPrefix('api');
+  app.enableVersioning({
+    type: VersioningType.URI,
+    defaultVersion: '1',
+  });
+  app.enableCors();
   await app.listen(process.env.PORT ?? 3000);
 }
 bootstrap();

--- a/src/openapi/api-contract.yaml
+++ b/src/openapi/api-contract.yaml
@@ -1,0 +1,531 @@
+openapi: 3.0.3
+info:
+  title: Education Platform API
+  version: '1.0.0'
+  description: >-
+    Contract for the education platform API covering authentication, user
+    management, course catalog and assignment submissions.
+servers:
+  - url: https://api.example.com/api/v1
+security:
+  - bearerAuth: []
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+  parameters:
+    IdempotencyKey:
+      name: Idempotency-Key
+      in: header
+      required: true
+      schema:
+        type: string
+      description: Replay protection key. Repeat calls with the same key receive the same response.
+paths:
+  /auth/login:
+    post:
+      summary: Exchange credentials for access tokens
+      tags: [Auth]
+      security: []
+      parameters:
+        - $ref: '#/components/parameters/IdempotencyKey'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [email, password]
+              properties:
+                email:
+                  type: string
+                  format: email
+                password:
+                  type: string
+                  minLength: 6
+                deviceId:
+                  type: string
+                deviceName:
+                  type: string
+      responses:
+        '200':
+          description: Tokens issued
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthTokens'
+        '401':
+          description: Invalid credentials
+  /auth/refresh:
+    post:
+      summary: Rotate access and refresh tokens
+      tags: [Auth]
+      security: []
+      parameters:
+        - $ref: '#/components/parameters/IdempotencyKey'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [refreshToken]
+              properties:
+                refreshToken:
+                  type: string
+      responses:
+        '200':
+          description: Tokens rotated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuthTokens'
+  /auth/sessions:
+    get:
+      summary: List active sessions for the current user
+      tags: [Auth]
+      responses:
+        '200':
+          description: Array of sessions
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Session'
+  /auth/sessions/{sessionId}:
+    delete:
+      summary: Revoke a session
+      tags: [Auth]
+      parameters:
+        - $ref: '#/components/parameters/IdempotencyKey'
+        - name: sessionId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Revocation acknowledged
+  /users:
+    get:
+      summary: List users with pagination
+      tags: [Users]
+      parameters:
+        - name: role
+          in: query
+          schema:
+            type: string
+            enum: [user, admin, moderator]
+        - name: search
+          in: query
+          schema:
+            type: string
+        - name: page
+          in: query
+          schema:
+            type: integer
+            default: 1
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            default: 10
+      responses:
+        '200':
+          description: Users page
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedUsers'
+  /users/{userId}:
+    get:
+      summary: Retrieve a user profile
+      tags: [Users]
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Public profile
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PublicUser'
+    patch:
+      summary: Update a user profile
+      tags: [Users]
+      parameters:
+        - $ref: '#/components/parameters/IdempotencyKey'
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [profile]
+              properties:
+                profile:
+                  $ref: '#/components/schemas/UserProfileUpdate'
+      responses:
+        '200':
+          description: Updated profile
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PublicUser'
+  /courses:
+    get:
+      summary: List courses
+      tags: [Courses]
+      parameters:
+        - name: tag
+          in: query
+          schema:
+            type: string
+        - name: instructorId
+          in: query
+          schema:
+            type: string
+        - name: search
+          in: query
+          schema:
+            type: string
+        - name: page
+          in: query
+          schema:
+            type: integer
+        - name: limit
+          in: query
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Paginated courses
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedCourses'
+    post:
+      summary: Create a new course
+      tags: [Courses]
+      parameters:
+        - $ref: '#/components/parameters/IdempotencyKey'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateCourse'
+      responses:
+        '201':
+          description: Course created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CourseDetail'
+  /courses/{courseId}:
+    get:
+      summary: Retrieve course details
+      tags: [Courses]
+      parameters:
+        - name: courseId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Course detail
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CourseDetail'
+  /submissions:
+    post:
+      summary: Submit assignment work
+      tags: [Submissions]
+      parameters:
+        - $ref: '#/components/parameters/IdempotencyKey'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateSubmission'
+      responses:
+        '201':
+          description: Submission accepted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Submission'
+  /submissions/outbox:
+    get:
+      summary: Inspect submission outbox events
+      tags: [Submissions]
+      responses:
+        '200':
+          description: Pending events
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/OutboxEvent'
+components:
+  schemas:
+    AuthTokens:
+      type: object
+      required: [tokenType, accessToken, expiresIn, refreshToken, session]
+      properties:
+        tokenType:
+          type: string
+          example: Bearer
+        accessToken:
+          type: string
+        expiresIn:
+          type: integer
+        refreshToken:
+          type: string
+        session:
+          $ref: '#/components/schemas/Session'
+    Session:
+      type: object
+      required: [id, createdAt, lastAccessedAt, expiresAt]
+      properties:
+        id:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        lastAccessedAt:
+          type: string
+          format: date-time
+        expiresAt:
+          type: string
+          format: date-time
+        device:
+          type: object
+          properties:
+            deviceId:
+              type: string
+            deviceName:
+              type: string
+            ipAddress:
+              type: string
+            userAgent:
+              type: string
+    UserProfile:
+      type: object
+      required: [displayName, locale]
+      properties:
+        displayName:
+          type: string
+        locale:
+          type: string
+        bio:
+          type: string
+    UserProfileUpdate:
+      type: object
+      properties:
+        displayName:
+          type: string
+        locale:
+          type: string
+        bio:
+          type: string
+    PublicUser:
+      type: object
+      required: [id, email, roles, profile]
+      properties:
+        id:
+          type: string
+        email:
+          type: string
+        roles:
+          type: array
+          items:
+            type: string
+        profile:
+          $ref: '#/components/schemas/UserProfile'
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+    PaginatedUsers:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/PublicUser'
+        pagination:
+          $ref: '#/components/schemas/PaginationMeta'
+    PaginationMeta:
+      type: object
+      properties:
+        page:
+          type: integer
+        limit:
+          type: integer
+        total:
+          type: integer
+    CourseSummary:
+      type: object
+      required: [id, title, description, tags, startsAt, endsAt, updatedAt]
+      properties:
+        id:
+          type: string
+        title:
+          type: string
+        description:
+          type: string
+        tags:
+          type: array
+          items:
+            type: string
+        startsAt:
+          type: string
+          format: date-time
+        endsAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+    CourseDetail:
+      allOf:
+        - $ref: '#/components/schemas/CourseSummary'
+        - type: object
+          required: [lessons, instructorId, createdAt, enrollment]
+          properties:
+            instructorId:
+              type: string
+            createdAt:
+              type: string
+              format: date-time
+            lessons:
+              type: array
+              items:
+                $ref: '#/components/schemas/CourseLesson'
+            enrollment:
+              type: object
+              properties:
+                capacity:
+                  type: integer
+                enrolled:
+                  type: integer
+                waitlisted:
+                  type: integer
+    CourseLesson:
+      type: object
+      required: [id, title, order, durationMinutes]
+      properties:
+        id:
+          type: string
+        title:
+          type: string
+        order:
+          type: integer
+        durationMinutes:
+          type: integer
+    PaginatedCourses:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/CourseSummary'
+        pagination:
+          $ref: '#/components/schemas/PaginationMeta'
+    CreateCourse:
+      type: object
+      required: [title, description, startsAt, endsAt, instructorId, lessons]
+      properties:
+        title:
+          type: string
+        description:
+          type: string
+        tags:
+          type: array
+          items:
+            type: string
+        startsAt:
+          type: string
+          format: date-time
+        endsAt:
+          type: string
+          format: date-time
+        instructorId:
+          type: string
+        capacity:
+          type: integer
+        lessons:
+          type: array
+          items:
+            type: object
+            required: [title, durationMinutes]
+            properties:
+              title:
+                type: string
+              durationMinutes:
+                type: integer
+    CreateSubmission:
+      type: object
+      required: [courseId, assignmentId, content]
+      properties:
+        courseId:
+          type: string
+        assignmentId:
+          type: string
+        content:
+          type: string
+        submittedAt:
+          type: string
+          format: date-time
+    Submission:
+      type: object
+      required: [id, userId, courseId, assignmentId, content, submittedAt]
+      properties:
+        id:
+          type: string
+        userId:
+          type: string
+        courseId:
+          type: string
+        assignmentId:
+          type: string
+        content:
+          type: string
+        submittedAt:
+          type: string
+          format: date-time
+    OutboxEvent:
+      type: object
+      required: [id, event, payload, createdAt]
+      properties:
+        id:
+          type: string
+        event:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        traceId:
+          type: string
+        payload:
+          type: object
+          additionalProperties: true

--- a/src/submissions/dto/create-submission.dto.ts
+++ b/src/submissions/dto/create-submission.dto.ts
@@ -1,0 +1,64 @@
+import { IsNotEmpty, IsOptional, IsString, MinLength } from 'class-validator';
+import { ensureRecord, runValidation, throwValidationException } from '../../common/utils/validation.util';
+
+const ISO_DATE_REGEX = /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z)$/;
+
+export class CreateSubmissionDto {
+  @IsString({ message: 'courseId must be a string.' })
+  @IsNotEmpty({ message: 'courseId is required and must be a non-empty string.' })
+  @MinLength(3, { message: 'courseId must be at least 3 characters.' })
+  courseId!: string;
+
+  @IsString({ message: 'assignmentId must be a string.' })
+  @IsNotEmpty({ message: 'assignmentId is required and must be a non-empty string.' })
+  @MinLength(3, { message: 'assignmentId must be at least 3 characters.' })
+  assignmentId!: string;
+
+  @IsString({ message: 'content must be a string.' })
+  @IsNotEmpty({ message: 'content is required and must be a non-empty string.' })
+  @MinLength(10, { message: 'content must be at least 10 characters.' })
+  content!: string;
+
+  @IsOptional()
+  @IsString({ message: 'submittedAt must be a string when provided.' })
+  submittedAt?: string;
+}
+
+export interface CreateSubmissionRequest {
+  courseId: string;
+  assignmentId: string;
+  content: string;
+  submittedAt: Date;
+}
+
+export function validateCreateSubmissionRequest(payload: unknown): CreateSubmissionRequest {
+  const errors: string[] = [];
+  const source = ensureRecord(payload, errors);
+
+  const dto = new CreateSubmissionDto();
+  Object.assign(dto, source);
+
+  dto.courseId = typeof dto.courseId === 'string' ? dto.courseId.trim() : dto.courseId;
+  dto.assignmentId = typeof dto.assignmentId === 'string' ? dto.assignmentId.trim() : dto.assignmentId;
+  dto.content = typeof dto.content === 'string' ? dto.content.trim() : dto.content;
+  dto.submittedAt = typeof dto.submittedAt === 'string' ? dto.submittedAt.trim() : dto.submittedAt;
+
+  if (dto.submittedAt && !ISO_DATE_REGEX.test(dto.submittedAt)) {
+    errors.push('submittedAt must be a valid ISO 8601 date when provided.');
+  }
+
+  runValidation(dto, errors);
+
+  if (errors.length > 0) {
+    throwValidationException(errors);
+  }
+
+  const submittedAt = dto.submittedAt ? new Date(dto.submittedAt) : new Date();
+
+  return {
+    courseId: dto.courseId,
+    assignmentId: dto.assignmentId,
+    content: dto.content,
+    submittedAt,
+  };
+}

--- a/src/submissions/interfaces/submission.interface.ts
+++ b/src/submissions/interfaces/submission.interface.ts
@@ -1,0 +1,18 @@
+export interface SubmissionRecord {
+  id: string;
+  userId: string;
+  courseId: string;
+  assignmentId: string;
+  content: string;
+  submittedAt: string;
+  gradedAt?: string;
+  grade?: number;
+}
+
+export interface OutboxEvent {
+  id: string;
+  event: string;
+  payload: Record<string, unknown>;
+  createdAt: string;
+  traceId?: string;
+}

--- a/src/submissions/submissions.controller.ts
+++ b/src/submissions/submissions.controller.ts
@@ -1,0 +1,34 @@
+import { Body, Controller, Get, HttpCode, HttpStatus, Post, Req } from '@nestjs/common';
+import { Request } from 'express';
+import { CurrentUser } from '../common/decorators/current-user.decorator';
+import { Idempotent } from '../common/decorators/idempotent.decorator';
+import { RateLimit } from '../common/decorators/rate-limit.decorator';
+import { Roles } from '../common/decorators/roles.decorator';
+import { Role } from '../common/types/role.enum';
+import { AuthenticatedUser } from '../auth/interfaces/authenticated-user.interface';
+import { validateCreateSubmissionRequest } from './dto/create-submission.dto';
+import { SubmissionsService } from './submissions.service';
+
+@Controller({ path: 'submissions', version: '1' })
+export class SubmissionsController {
+  constructor(private readonly submissionsService: SubmissionsService) {}
+
+  @Post()
+  @Idempotent()
+  @RateLimit({ limit: 20, windowMs: 60_000 })
+  @HttpCode(HttpStatus.CREATED)
+  submitAssignment(
+    @CurrentUser() user: AuthenticatedUser,
+    @Body() body: unknown,
+    @Req() request: Request,
+  ) {
+    const payload = validateCreateSubmissionRequest(body);
+    return this.submissionsService.createSubmission(user.id, payload, request.traceId);
+  }
+
+  @Get('outbox')
+  @Roles(Role.Admin)
+  listOutboxEvents() {
+    return this.submissionsService.listOutboxEvents();
+  }
+}

--- a/src/submissions/submissions.module.ts
+++ b/src/submissions/submissions.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { CommonModule } from '../common/common.module';
+import { CoursesModule } from '../courses/courses.module';
+import { SubmissionsController } from './submissions.controller';
+import { SubmissionsService } from './submissions.service';
+
+@Module({
+  imports: [CommonModule, CoursesModule],
+  controllers: [SubmissionsController],
+  providers: [SubmissionsService],
+})
+export class SubmissionsModule {}

--- a/src/submissions/submissions.service.ts
+++ b/src/submissions/submissions.service.ts
@@ -1,0 +1,70 @@
+import { ForbiddenException, Injectable } from '@nestjs/common';
+import { randomUUID } from 'crypto';
+import { AuditService } from '../common/services/audit.service';
+import { CoursesService } from '../courses/courses.service';
+import { CreateSubmissionRequest } from './dto/create-submission.dto';
+import { OutboxEvent, SubmissionRecord } from './interfaces/submission.interface';
+
+@Injectable()
+export class SubmissionsService {
+  private readonly submissions: SubmissionRecord[] = [];
+  private readonly outbox: OutboxEvent[] = [];
+
+  constructor(private readonly coursesService: CoursesService, private readonly auditService: AuditService) {}
+
+  createSubmission(
+    userId: string,
+    request: CreateSubmissionRequest,
+    traceId: string | undefined,
+  ): SubmissionRecord {
+    const enrolled = this.coursesService.isUserEnrolled(request.courseId, userId);
+    if (!enrolled) {
+      throw new ForbiddenException({
+        code: 'COURSE_ENROLLMENT_REQUIRED',
+        message: 'You must be enrolled in the course to submit this assignment.',
+      });
+    }
+
+    const submission: SubmissionRecord = {
+      id: randomUUID(),
+      userId,
+      courseId: request.courseId,
+      assignmentId: request.assignmentId,
+      content: request.content,
+      submittedAt: request.submittedAt.toISOString(),
+    };
+
+    this.submissions.push(submission);
+
+    const event: OutboxEvent = {
+      id: randomUUID(),
+      event: 'submission.created',
+      payload: {
+        submissionId: submission.id,
+        userId,
+        courseId: submission.courseId,
+        assignmentId: submission.assignmentId,
+        submittedAt: submission.submittedAt,
+      },
+      createdAt: new Date().toISOString(),
+      traceId,
+    };
+
+    this.outbox.push(event);
+
+    this.auditService.record('submission.created', {
+      userId,
+      traceId,
+      metadata: {
+        submissionId: submission.id,
+        courseId: submission.courseId,
+      },
+    });
+
+    return submission;
+  }
+
+  listOutboxEvents(): OutboxEvent[] {
+    return [...this.outbox];
+  }
+}

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -1,0 +1,8 @@
+import { AuthenticatedUser } from '../auth/interfaces/authenticated-user.interface';
+
+declare module 'express-serve-static-core' {
+  interface Request {
+    user?: AuthenticatedUser;
+    traceId?: string;
+  }
+}

--- a/src/users/dto/list-users.dto.ts
+++ b/src/users/dto/list-users.dto.ts
@@ -1,0 +1,65 @@
+import { IsEnum, IsNotEmpty, IsOptional, IsString, MaxLength } from 'class-validator';
+import { Role } from '../../common/types/role.enum';
+import { ensureRecord, runValidation, throwValidationException } from '../../common/utils/validation.util';
+
+export class ListUsersQueryDto {
+  @IsOptional()
+  @IsEnum(Role, { message: 'role must be one of user, admin, moderator.' })
+  role?: Role;
+
+  @IsOptional()
+  @IsString({ message: 'search must be a string.' })
+  @IsNotEmpty({ message: 'search cannot be empty when provided.' })
+  @MaxLength(120, { message: 'search must be at most 120 characters.' })
+  search?: string;
+
+  page = 1;
+  limit = 10;
+}
+
+export type ListUsersQuery = ListUsersQueryDto;
+
+export function validateListUsersQuery(query: Record<string, unknown>): ListUsersQueryDto {
+  const errors: string[] = [];
+  const source = ensureRecord(query, errors);
+
+  const dto = new ListUsersQueryDto();
+  Object.assign(dto, source);
+
+  if (typeof dto.search === 'string') {
+    dto.search = dto.search.trim();
+  }
+
+  const pageValue = source.page ?? dto.page;
+  const limitValue = source.limit ?? dto.limit;
+
+  const parsedPage = Number(pageValue);
+  if (pageValue !== undefined) {
+    if (Number.isNaN(parsedPage)) {
+      errors.push('page must be a numeric value.');
+    } else if (!Number.isInteger(parsedPage) || parsedPage < 1) {
+      errors.push('page must be an integer greater than or equal to 1.');
+    } else {
+      dto.page = parsedPage;
+    }
+  }
+
+  const parsedLimit = Number(limitValue);
+  if (limitValue !== undefined) {
+    if (Number.isNaN(parsedLimit)) {
+      errors.push('limit must be a numeric value.');
+    } else if (!Number.isInteger(parsedLimit) || parsedLimit < 1 || parsedLimit > 100) {
+      errors.push('limit must be an integer between 1 and 100.');
+    } else {
+      dto.limit = parsedLimit;
+    }
+  }
+
+  runValidation(dto, errors);
+
+  if (errors.length > 0) {
+    throwValidationException(errors);
+  }
+
+  return dto;
+}

--- a/src/users/dto/update-user.dto.ts
+++ b/src/users/dto/update-user.dto.ts
@@ -1,0 +1,75 @@
+import { IsNotEmpty, IsOptional, IsString, Matches, MaxLength, MinLength } from 'class-validator';
+import { ensureRecord, runValidation, throwValidationException } from '../../common/utils/validation.util';
+import { UserProfile } from '../interfaces/user.interface';
+
+export class UpdateUserProfileDto {
+  @IsOptional()
+  @IsString({ message: 'profile.displayName must be a string when provided.' })
+  @IsNotEmpty({ message: 'profile.displayName cannot be empty when provided.' })
+  @MinLength(2, { message: 'profile.displayName must be at least 2 characters.' })
+  @MaxLength(80, { message: 'profile.displayName must be at most 80 characters.' })
+  displayName?: string;
+
+  @IsOptional()
+  @IsString({ message: 'profile.locale must be a string when provided.' })
+  @Matches(/^[a-z]{2}-[A-Z]{2}$/, {
+    message: 'profile.locale must match the pattern ll-CC (e.g. en-US).',
+  })
+  locale?: string;
+
+  @IsOptional()
+  @IsString({ message: 'profile.bio must be a string when provided.' })
+  @MaxLength(500, { message: 'profile.bio must be at most 500 characters.' })
+  bio?: string;
+}
+
+export class UpdateUserDto {
+  profile!: UpdateUserProfileDto;
+}
+
+export interface UpdateUserRequest {
+  profile: Partial<UserProfile>;
+}
+
+export function validateUpdateUserRequest(payload: unknown): UpdateUserRequest {
+  const errors: string[] = [];
+  const source = ensureRecord(payload, errors);
+
+  const profileSource = source.profile;
+  if (!profileSource || typeof profileSource !== 'object' || Array.isArray(profileSource)) {
+    errors.push('profile is required and must be an object.');
+    throwValidationException(errors);
+  }
+
+  const profileDto = new UpdateUserProfileDto();
+  Object.assign(profileDto, profileSource as Record<string, unknown>);
+
+  if (typeof profileDto.displayName === 'string') {
+    profileDto.displayName = profileDto.displayName.trim();
+  }
+  if (typeof profileDto.locale === 'string') {
+    profileDto.locale = profileDto.locale.trim();
+  }
+  if (typeof profileDto.bio === 'string') {
+    profileDto.bio = profileDto.bio.trim();
+  }
+
+  runValidation(profileDto, errors);
+
+  if (errors.length > 0) {
+    throwValidationException(errors);
+  }
+
+  const profile: Partial<UserProfile> = {};
+  if (profileDto.displayName !== undefined) {
+    profile.displayName = profileDto.displayName;
+  }
+  if (profileDto.locale !== undefined) {
+    profile.locale = profileDto.locale;
+  }
+  if (profileDto.bio !== undefined) {
+    profile.bio = profileDto.bio;
+  }
+
+  return { profile };
+}

--- a/src/users/interfaces/user.interface.ts
+++ b/src/users/interfaces/user.interface.ts
@@ -1,0 +1,26 @@
+import { Role } from '../../common/types/role.enum';
+
+export interface UserProfile {
+  displayName: string;
+  locale: string;
+  bio?: string;
+}
+
+export interface UserRecord {
+  id: string;
+  email: string;
+  password: string;
+  roles: Role[];
+  profile: UserProfile;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface PublicUser {
+  id: string;
+  email: string;
+  roles: Role[];
+  profile: UserProfile;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -1,0 +1,57 @@
+import { Controller, Get, Param, Patch, Query, Body, Req, ForbiddenException } from '@nestjs/common';
+import { Request } from 'express';
+import { CurrentUser } from '../common/decorators/current-user.decorator';
+import { Idempotent } from '../common/decorators/idempotent.decorator';
+import { RateLimit } from '../common/decorators/rate-limit.decorator';
+import { Roles } from '../common/decorators/roles.decorator';
+import { Role } from '../common/types/role.enum';
+import { AuthenticatedUser } from '../auth/interfaces/authenticated-user.interface';
+import { UsersService } from './users.service';
+import { validateListUsersQuery } from './dto/list-users.dto';
+import { validateUpdateUserRequest } from './dto/update-user.dto';
+
+@Controller({ path: 'users', version: '1' })
+export class UsersController {
+  constructor(private readonly usersService: UsersService) {}
+
+  @Get()
+  @Roles(Role.Admin, Role.Moderator)
+  list(@Query() query: Record<string, unknown>) {
+    const filters = validateListUsersQuery(query);
+    return this.usersService.listUsers(filters);
+  }
+
+  @Get(':id')
+  getUser(@Param('id') userId: string, @CurrentUser() currentUser: AuthenticatedUser) {
+    const isSelf = currentUser.id === userId;
+    const hasPrivilege = currentUser.roles.includes(Role.Admin) || currentUser.roles.includes(Role.Moderator);
+    if (!isSelf && !hasPrivilege) {
+      throw new ForbiddenException({
+        code: 'ACCESS_DENIED',
+        message: 'You are not allowed to view this profile.',
+      });
+    }
+    return this.usersService.findById(userId);
+  }
+
+  @Patch(':id')
+  @Idempotent()
+  @RateLimit({ limit: 30, windowMs: 60_000 })
+  updateUser(
+    @Param('id') userId: string,
+    @CurrentUser() currentUser: AuthenticatedUser,
+    @Body() body: unknown,
+    @Req() request: Request,
+  ) {
+    const isSelf = currentUser.id === userId;
+    const isAdmin = currentUser.roles.includes(Role.Admin);
+    if (!isSelf && !isAdmin) {
+      throw new ForbiddenException({
+        code: 'NOT_OWNER_OF_PROFILE',
+        message: 'You can only update your own profile unless you are an administrator.',
+      });
+    }
+    const updateRequest = validateUpdateUserRequest(body);
+    return this.usersService.updateUser(userId, updateRequest, request.traceId);
+  }
+}

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { CommonModule } from '../common/common.module';
+import { UsersController } from './users.controller';
+import { UsersService } from './users.service';
+
+@Module({
+  imports: [CommonModule],
+  controllers: [UsersController],
+  providers: [UsersService],
+  exports: [UsersService],
+})
+export class UsersModule {}

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -1,0 +1,138 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { AuditService } from '../common/services/audit.service';
+import { Role } from '../common/types/role.enum';
+import { paginateArray, PaginatedResult } from '../common/utils/pagination.util';
+import { ListUsersQuery } from './dto/list-users.dto';
+import { UpdateUserRequest } from './dto/update-user.dto';
+import { PublicUser, UserProfile, UserRecord } from './interfaces/user.interface';
+
+@Injectable()
+export class UsersService {
+  private readonly users: UserRecord[] = [
+    {
+      id: 'user-learner',
+      email: 'learner@example.com',
+      password: 'Learner#123',
+      roles: [Role.User],
+      profile: {
+        displayName: 'Learner One',
+        locale: 'en-US',
+        bio: 'Focused on mastering backend development.',
+      },
+      createdAt: '2024-01-10T09:00:00.000Z',
+      updatedAt: '2024-01-10T09:00:00.000Z',
+    },
+    {
+      id: 'user-instructor',
+      email: 'instructor@example.com',
+      password: 'Instructor#123',
+      roles: [Role.Moderator],
+      profile: {
+        displayName: 'Instructor Jane',
+        locale: 'en-US',
+        bio: 'Teaches advanced NestJS workshops.',
+      },
+      createdAt: '2024-01-05T08:30:00.000Z',
+      updatedAt: '2024-01-05T08:30:00.000Z',
+    },
+    {
+      id: 'user-admin',
+      email: 'admin@example.com',
+      password: 'Admin#123',
+      roles: [Role.Admin],
+      profile: {
+        displayName: 'Platform Admin',
+        locale: 'en-US',
+        bio: 'Ensures operations run smoothly.',
+      },
+      createdAt: '2023-12-30T12:00:00.000Z',
+      updatedAt: '2023-12-30T12:00:00.000Z',
+    },
+  ];
+
+  constructor(private readonly auditService: AuditService) {}
+
+  listUsers(query: ListUsersQuery): PaginatedResult<PublicUser> {
+    const filtered = this.users.filter((user) => {
+      if (query.role && !user.roles.includes(query.role)) {
+        return false;
+      }
+      if (query.search) {
+        const normalized = query.search.toLowerCase();
+        return (
+          user.email.toLowerCase().includes(normalized) ||
+          user.profile.displayName.toLowerCase().includes(normalized)
+        );
+      }
+      return true;
+    });
+
+    const sorted = [...filtered].sort((a, b) => a.email.localeCompare(b.email));
+    const paginated = paginateArray(sorted, { page: query.page, limit: query.limit });
+
+    return {
+      data: paginated.data.map((user) => this.toPublicUser(user)),
+      pagination: paginated.pagination,
+    };
+  }
+
+  findById(userId: string): PublicUser {
+    const record = this.findUserRecordById(userId);
+    if (!record) {
+      throw new NotFoundException({
+        code: 'USER_NOT_FOUND',
+        message: 'User could not be found.',
+      });
+    }
+    return this.toPublicUser(record);
+  }
+
+  updateUser(userId: string, request: UpdateUserRequest, traceId: string | undefined): PublicUser {
+    const record = this.findUserRecordById(userId);
+    if (!record) {
+      throw new NotFoundException({
+        code: 'USER_NOT_FOUND',
+        message: 'User could not be found.',
+      });
+    }
+
+    const updatedProfile: UserProfile = {
+      ...record.profile,
+      ...request.profile,
+    };
+
+    const now = new Date().toISOString();
+    record.profile = updatedProfile;
+    record.updatedAt = now;
+
+    this.auditService.record('user.profile.updated', {
+      userId,
+      traceId,
+      metadata: {
+        updatedFields: Object.keys(request.profile),
+      },
+    });
+
+    return this.toPublicUser(record);
+  }
+
+  validateCredentials(email: string, password: string): UserRecord | undefined {
+    const normalizedEmail = email.toLowerCase();
+    return this.users.find((user) => user.email.toLowerCase() === normalizedEmail && user.password === password);
+  }
+
+  findUserRecordById(userId: string): UserRecord | undefined {
+    return this.users.find((user) => user.id === userId);
+  }
+
+  private toPublicUser(user: UserRecord): PublicUser {
+    return {
+      id: user.id,
+      email: user.email,
+      roles: [...user.roles],
+      profile: { ...user.profile },
+      createdAt: user.createdAt,
+      updatedAt: user.updatedAt,
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- replace the bespoke DTO validators with class-validator-decorated DTO classes across auth, course, submission and user flows while preserving trimming and defaults
- add a shared validation helper that executes class-validator and raises the existing error envelope
- vendor a lightweight class-validator implementation so validation works without fetching external packages

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cae896c9908326aa2487e38d35bcf9